### PR TITLE
removing faulty 'needs: test' logic from deploy.yaml, as project coul…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,8 +34,6 @@ jobs:
   deploy:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
-    # Ensures that deploy does not happen unless test is successful.
-    needs: test
     steps:
       - name: Check out code
         uses: actions/checkout@v3


### PR DESCRIPTION
…d not be deployed since a PR is not considered a push